### PR TITLE
Extended the blazegraph timeout to 30 seconds.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -62,7 +62,7 @@ http_status_container() {
   debug_msg "$cnt $url"
   status="0"
   count=0
-  maxcount=10
+  maxcount=30
   while [ $status -ne "200" -a $count -lt $maxcount ]
   do
     status=$(curl -s --head -w %{http_code} "$url" -o /dev/null)


### PR DESCRIPTION
Extended the blazegraph timeout to 30 seconds.

Issue #878

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-docker/13)
<!-- Reviewable:end -->
