### PR TITLE
Added support for running X11 apps from container shell command line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,13 +77,13 @@ services:
     environment:
       - PATH=/gridappsd/bin:/gridappsd/lib:/gridappsd/services/fncsgossbridge/service:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
       # X11 application support--use same display as host, typically ":0"
-      - DISPLAY=${DISPLAY}
+      # - DISPLAY=${DISPLAY}
       # Debugging is only necessary if you intend to remote debug the GridAPPS-D process iself.
       # Turning this on will allow the user to remote debug the gridappsd server on port 8000.
       - DEBUG=1
-    volumes:
+    # volumes:
       # X11 application support--share X11 port with container host
-      - /tmp/.X11-unix:/tmp/.X11-unix
+      # - /tmp/.X11-unix:/tmp/.X11-unix
 # The following allow applications to be mounted into the container so that
 # gridappsd can start them in the correct context.
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,9 +76,14 @@ services:
     working_dir: /gridappsd
     environment:
       - PATH=/gridappsd/bin:/gridappsd/lib:/gridappsd/services/fncsgossbridge/service:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+      # X11 application support--use same display as host, typically ":0"
+      - DISPLAY=${DISPLAY}
       # Debugging is only necessary if you intend to remote debug the GridAPPS-D process iself.
       # Turning this on will allow the user to remote debug the gridappsd server on port 8000.
       - DEBUG=1
+    volumes:
+      # X11 application support--share X11 port with container host
+      - /tmp/.X11-unix:/tmp/.X11-unix
 # The following allow applications to be mounted into the container so that
 # gridappsd can start them in the correct context.
 #


### PR DESCRIPTION
Running X Windows applications, including the state-plotter application that uses the Matplotlib Python library, from within a container, the X11 port used by the container host must be a bind mount volume so it is shared and then the $DISPLAY variable must also be the same as the host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-docker/23)
<!-- Reviewable:end -->
