### PR TITLE
gridappsd-shell unexpected operator error fix

### DIFF
--- a/gridappsd-shell
+++ b/gridappsd-shell
@@ -1,5 +1,5 @@
 
-if [ $# == 1 ]; then
+if [ $# -eq 1 ]; then
   docker exec -u $1 -it gridappsd /bin/bash
 else
   docker exec -it gridappsd /bin/bash


### PR DESCRIPTION
Every time gridappsd-shell is run an unexpected operator error is encountered because == is being used to compare two numbers when -eq should be used. This PR provides that fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gridappsd/gridappsd-docker/49)
<!-- Reviewable:end -->
