### PR TITLE
updating compose file for issue 1864

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,8 @@ services:
             retries: 3
             start_period: 60s
         environment:
-            - PATH=/home/gridappsd/.local/bin:/gridappsd/bin:/gridappsd/lib:/gridappsd/services/fncsgossbridge/service:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
-            - LD_LIBRARY_PATH=/usr/local/lib64
+            - PATH=/home/gridappsd/.local/bin:/gridappsd/bin:/gridappsd/lib:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+            # - LD_LIBRARY_PATH=/usr/local/lib64
             # Start the platform on boot
             - AUTOSTART=1
             # X11 application support--use same display as host, typically ":0"


### PR DESCRIPTION
Prevents environment variable LD_LIBRARY_PATH from being overwritten from what was set in the base image.

To test: 
1) Build the gridappsd base image from feature/1864 branch of the gridappsd-docker-build repo: docker build --build-arg GRIDAPPSD_TAG=:feature-1864
2) Build the gridappsd image using this base image: ./build-gridappsd-container --base-version feature-1864
3) Checkout branch feature/1864 of gridappsd-docker repo make sure to modify docker-compose.yml to use your local gridappsd image. build the containers: ./run.sh -n -t develop.
4) Run a simulation  from the viz.