### PR TITLE
feat: reachable-URL banner after platform-mode bring-up

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -331,14 +331,7 @@ elif [ $no_autostart -eq 1 ] && tty -s ; then
 else
   echo " "
   echo "GridAPPS-D is starting automatically."
-  echo " "
-  echo "Available endpoints:"
-  echo "  Web UI:        http://localhost:8080/"
-  echo "  Blazegraph:    http://localhost:8889/bigdata/"
-  echo "  STOMP:         tcp://localhost:61613"
-  echo "  WebSocket:     ws://localhost:61614"
-  echo "  OpenWire:      tcp://localhost:61616"
-  echo " "
+  print_access_urls
   echo "To connect to the container:"
   echo "  docker exec -it gridappsd /bin/bash"
   echo " "

--- a/tests/stubs/docker
+++ b/tests/stubs/docker
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Stub for docker, used only by bats tests.
+# Understands exactly the call shape _published_host_port uses:
+#   docker port <container_name> <container_port>
+#
+# Reads published-port data from $DOCKER_STUB_DIR/<container_name>.ports.
+# Each line in that file:
+#   <container_port>  <bind_address>:<host_port>
+# where <bind_address> may be 0.0.0.0, 127.0.0.1, [::], or ::
+# (mirrors the four forms the real `docker port` command emits).
+# Multiple lines per container_port are supported (one per bind address).
+#
+# If the .ports file is absent, the container is not running (exits 1).
+# If the file exists but the requested port has no entry, exits 1.
+# All other docker subcommands exit 0 with no output (silently ignored).
+set -euo pipefail
+
+if [ "${1:-}" != "port" ]; then
+  exit 0
+fi
+
+container_name="${2:-}"
+container_port="${3:-}"
+
+if [ -z "$container_name" ] || [ -z "${DOCKER_STUB_DIR:-}" ]; then
+  exit 1
+fi
+
+ports_file="${DOCKER_STUB_DIR}/${container_name}.ports"
+if [ ! -f "$ports_file" ]; then
+  echo "Error response from daemon: No such container: ${container_name}" >&2
+  exit 1
+fi
+
+# Collect all binding lines for the requested container port.
+match=$(grep "^${container_port}[[:space:]]" "$ports_file" 2>/dev/null || true)
+if [ -z "$match" ]; then
+  echo "Error: No public port '${container_port}' published for ${container_name}" >&2
+  exit 1
+fi
+
+# Emit the bind-address:host_port field verbatim, one line per binding,
+# matching the real docker port output format.
+printf '%s\n' "$match" | awk '{print $2}'

--- a/tests/test_url_banner.bats
+++ b/tests/test_url_banner.bats
@@ -1,0 +1,281 @@
+#!/usr/bin/env bats
+#
+# Smoke tests for print_access_urls() from utils.sh (dynamic runtime-state variant).
+#
+# Tests stub `docker` via a PATH-prepended stub (tests/stubs/docker) that reads
+# per-container port data from $DOCKER_STUB_DIR/<name>.ports. Absent file means
+# the container is not running; a file present but missing the requested port
+# means the container runs but does not publish that port.
+#
+# Assertions check actual URL strings in output (not just exit 0), per
+# [[data-invariants]] Rule 1.
+
+REPO_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+STUBS_DIR="${REPO_DIR}/tests/stubs"
+
+setup() {
+  # Temp dir for per-container stub .ports files
+  DOCKER_STUB_DIR="$(mktemp -d)"
+  export DOCKER_STUB_DIR
+
+  # Prepend the stubs directory so our docker stub wins over the real docker
+  PATH="${STUBS_DIR}:${PATH}"
+  export PATH
+
+  # Source utils.sh to define _published_host_port and print_access_urls.
+  # utils.sh has no top-level function calls; safe to source without real docker.
+  # SC1091: path computed at runtime from REPO_DIR, cannot be followed statically.
+  # shellcheck disable=SC1091
+  source "${REPO_DIR}/utils.sh"
+}
+
+teardown() {
+  rm -rf "${DOCKER_STUB_DIR}"
+}
+
+# Helper: register a published port for a container in the stub.
+# Usage: stub_port <container_name> <container_port> <host_port> [bind_address]
+# bind_address defaults to 0.0.0.0 when omitted.
+# Pass e.g. "127.0.0.1", "[::]", or "::" to test alternate bind forms.
+stub_port() {
+  local name="$1" cport="$2" hport="$3" bind="${4:-0.0.0.0}"
+  printf '%s\t%s:%s\n' "$cport" "$bind" "$hport" >> "${DOCKER_STUB_DIR}/${name}.ports"
+}
+
+# ---------------------------------------------------------------------------
+# Base platform: published ports produce URLs
+# ---------------------------------------------------------------------------
+
+@test "viz running on default port: Viz URL is printed" {
+  stub_port viz 8082 8080
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:8080"* ]]
+}
+
+@test "gridappsd running on API port: API URL is printed" {
+  stub_port gridappsd 8000 8000
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:8000"* ]]
+}
+
+@test "blazegraph running: Blazegraph URL is printed" {
+  stub_port blazegraph 8080 8889
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:8889"* ]]
+}
+
+@test "influxdb running: InfluxDB URL is printed" {
+  stub_port influxdb 8086 8086
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:8086"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Not-running: no URL line when container stub file is absent
+# ---------------------------------------------------------------------------
+
+@test "viz not running: no Viz URL in output" {
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Viz"* ]]
+}
+
+@test "blazegraph not running: no Blazegraph URL in output" {
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:8889"* ]]
+}
+
+@test "influxdb not running: no InfluxDB URL in output" {
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:8086"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Not-publishing: container stub file exists but requested port not in it
+# ---------------------------------------------------------------------------
+
+@test "gridappsd running but API port not published: no API URL" {
+  # Container is up (file exists) but only STOMP is published, not 8000
+  stub_port gridappsd 61613 61613
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:8000"* ]]
+}
+
+@test "gridappsd running but STOMP not published: no STOMP URL" {
+  stub_port gridappsd 8000 8000
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:61613"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Observability: only when containers are actually running
+# ---------------------------------------------------------------------------
+
+@test "grafana running: Grafana URL is printed" {
+  stub_port grafana 3000 4000
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:4000"* ]]
+}
+
+@test "prometheus running: Prometheus URL is printed" {
+  stub_port prometheus 9090 9090
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:9090"* ]]
+}
+
+@test "grafana NOT running: no Grafana URL" {
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:4000"* ]]
+}
+
+@test "loki NOT running: no Loki URL" {
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:3100"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Numeric-port guard: garbage docker port output yields no URL
+# ---------------------------------------------------------------------------
+
+@test "docker port returns non-numeric garbage: no URL printed for that surface" {
+  # Write a stub line whose second field is not a numeric port after the colon
+  printf '3000\t0.0.0.0:not-a-port\n' >> "${DOCKER_STUB_DIR}/grafana.ports"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"localhost:not-a-port"* ]]
+  [[ "$output" != *"Grafana"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Empty-state header: no surfaces running means no header
+# ---------------------------------------------------------------------------
+
+@test "no containers running: header is not printed" {
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Platform is up. Reachable surfaces:"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Bind-address agnostic: port extracted correctly across all bind forms.
+# These cases gate the GADO-006 forward-compatibility fix.
+# ---------------------------------------------------------------------------
+
+@test "grafana bound to 0.0.0.0 (standard): URL prints with correct port" {
+  stub_port grafana 3000 4000 "0.0.0.0"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:4000"* ]]
+}
+
+@test "grafana bound to 127.0.0.1 (GADO-006 loopback rebind): URL still prints" {
+  stub_port grafana 3000 4000 "127.0.0.1"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:4000"* ]]
+}
+
+@test "loki bound to [::] (IPv6 bracketed) only: URL prints with correct port" {
+  stub_port loki 3100 3100 "[::]"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:3100"* ]]
+}
+
+@test "tempo bound to :: (IPv6 bare) only: URL prints with correct port" {
+  stub_port tempo 3200 3200 "::"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:3200"* ]]
+}
+
+@test "grafana bound to both 0.0.0.0 and [::]: URL printed once with correct port" {
+  # Real docker port output has two lines (IPv4 then IPv6); function prefers IPv4
+  stub_port grafana 3000 4000 "0.0.0.0"
+  stub_port grafana 3000 4000 "[::]"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:4000"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Remap: operator-remapped host port prints the actual port, not the default
+# ---------------------------------------------------------------------------
+
+@test "grafana remapped to 127.0.0.1:4001 (loopback remap): URL prints 4001 not 4000" {
+  # Covers both the remap and the loopback-bind correctness in one assertion.
+  stub_port grafana 3000 4001 "127.0.0.1"
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:4001"* ]]
+  [[ "$output" != *"localhost:4000"* ]]
+}
+
+@test "viz remapped to host port 9080: URL prints 9080 not 8080" {
+  stub_port viz 8082 9080
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:9080"* ]]
+  [[ "$output" != *"localhost:8080"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Full platform + observability all up: all expected URLs present
+# ---------------------------------------------------------------------------
+
+@test "all base and observability running: all URLs present" {
+  stub_port viz        8082  8080
+  stub_port gridappsd  8000  8000
+  stub_port gridappsd 61613 61613
+  stub_port gridappsd 61614 61614
+  stub_port gridappsd 61616 61616
+  stub_port blazegraph 8080  8889
+  stub_port influxdb   8086  8086
+  stub_port grafana    3000  4000
+  stub_port prometheus 9090  9090
+  stub_port loki       3100  3100
+  stub_port tempo      3200  3200
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:8080"* ]]
+  [[ "$output" == *"http://localhost:8000"* ]]
+  [[ "$output" == *"http://localhost:8889"* ]]
+  [[ "$output" == *"http://localhost:8086"* ]]
+  [[ "$output" == *"tcp://localhost:61613"* ]]
+  [[ "$output" == *"ws://localhost:61614"* ]]
+  [[ "$output" == *"tcp://localhost:61616"* ]]
+  [[ "$output" == *"http://localhost:4000"* ]]
+  [[ "$output" == *"http://localhost:9090"* ]]
+  [[ "$output" == *"http://localhost:3100"* ]]
+  [[ "$output" == *"http://localhost:3200"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Observability down, base up: observability URLs absent
+# ---------------------------------------------------------------------------
+
+@test "base up, observability containers not running: no observability URLs" {
+  stub_port viz        8082  8080
+  stub_port gridappsd  8000  8000
+  stub_port blazegraph 8080  8889
+  stub_port influxdb   8086  8086
+  run print_access_urls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"http://localhost:8080"* ]]
+  [[ "$output" != *"localhost:4000"* ]]
+  [[ "$output" != *"localhost:9090"* ]]
+  [[ "$output" != *"localhost:3100"* ]]
+  [[ "$output" != *"localhost:3200"* ]]
+}

--- a/utils.sh
+++ b/utils.sh
@@ -34,3 +34,133 @@ get_compose_files() {
   local files=$( ls -1 docker-compose.d/*yml 2>/dev/null | sed -e 's/^/-f /g' | tr '\n' ' ' )
   echo "-f docker-compose.yml $files"
 }
+
+# Resolve the actual published host port for a running container.
+# Usage: _published_host_port <container_name> <container_port>
+# Prints the host port (digits only) if the container is running and publishing
+# that port; prints nothing and returns 1 otherwise.
+# Uses `docker port`, which is available on both `docker compose` and legacy
+# `docker-compose` installs because it is a plain docker CLI command.
+_published_host_port() {
+  local name="$1"
+  local cport="$2"
+  local output line port
+
+  # docker port exits nonzero and writes to stderr when the container is absent
+  # or the port is not published; capture output, suppress stderr, and neutralise
+  # the nonzero exit so set -e (if active in the caller) does not abort.
+  output=$(docker port "$name" "$cport" 2>/dev/null) || true
+  if [ -z "$output" ]; then
+    return 1
+  fi
+
+  # Extract the published host port regardless of bind address.
+  # docker port lines come in four forms:
+  #   0.0.0.0:PORT      (IPv4 any)
+  #   127.0.0.1:PORT    (IPv4 loopback, used by GADO-006 rebind)
+  #   [::]:PORT         (IPv6 bracketed)
+  #   :::PORT           (IPv6 bare)
+  # Strategy: prefer the first IPv4 line (does not start with [ or ::) because
+  # it is always present when a port is published on an IPv4 interface.
+  # Fall back to the first line when only an IPv6 binding exists.
+  # ${line##*:} strips everything up to and including the last colon, yielding
+  # just the PORT digits for all four formats above.
+  line=$(printf '%s\n' "$output" | grep -v -e '^\[' -e '^::' | head -1)
+  if [ -z "$line" ]; then
+    line=$(printf '%s\n' "$output" | head -1)
+  fi
+
+  port="${line##*:}"
+  # Reject empty or non-numeric port; guards against malformed docker output.
+  case "$port" in
+    ""|*[!0-9]*) return 1 ;;
+  esac
+  echo "$port"
+}
+
+# Print a human-readable access URL list driven by ACTUAL RUNTIME STATE.
+#
+# For each known surface, queries `docker port <container> <container_port>` to
+# learn the actual published host port. A line is printed ONLY if the container
+# is running and that port is currently published. A remap (e.g. grafana on 4001
+# instead of the default 4000) is honoured automatically because the host port
+# comes from the live container, not a hardcoded literal.
+#
+# Known surfaces in display order (container_name|container_port|label|scheme|path):
+#   viz         8082  GridAPPS-D Viz (main UI)   http  /
+#   gridappsd   8000  GridAPPS-D API             http  /
+#   blazegraph  8080  Blazegraph (triplestore)   http  /bigdata/
+#   influxdb    8086  InfluxDB                   http  /
+#   gridappsd  61613  STOMP                      tcp   (no path)
+#   gridappsd  61614  WebSocket                  ws    (no path)
+#   gridappsd  61616  OpenWire                   tcp   (no path)
+#   grafana     3000  Grafana                    http  /
+#   prometheus  9090  Prometheus                 http  /
+#   loki        3100  Loki                       http  /
+#   tempo       3200  Tempo                      http  /
+#
+# An unknown container/port that is running and publishing will be silently
+# omitted because the label map is exhaustive for the services defined across
+# docker-compose.yml and docker-compose.d/*.yml.dist. Adding a new service
+# means adding a row here.
+#
+# Call once, after a successful docker compose up, in the platform-mode
+# (autostart) path of run.sh. Do NOT call in services-only (-s) mode or in the
+# no-autostart (-n) container-shell path.
+print_access_urls() {
+  local host_port label scheme path_suffix url
+  local header_printed=0
+  local container cport rest
+
+  # Each element: container_name|container_port|label|scheme|url_path
+  # Ordered for display: base platform first, then observability.
+  local surfaces=(
+    "viz|8082|GridAPPS-D Viz (main UI)|http|/"
+    "gridappsd|8000|GridAPPS-D API|http|/"
+    "blazegraph|8080|Blazegraph (triplestore)|http|/bigdata/"
+    "influxdb|8086|InfluxDB|http|/"
+    "gridappsd|61613|STOMP|tcp|"
+    "gridappsd|61614|WebSocket|ws|"
+    "gridappsd|61616|OpenWire|tcp|"
+    "grafana|3000|Grafana|http|/"
+    "prometheus|9090|Prometheus|http|/"
+    "loki|3100|Loki|http|/"
+    "tempo|3200|Tempo|http|/"
+  )
+
+  for surface in "${surfaces[@]}"; do
+    # Split on | using parameter expansion; no subshell needed.
+    container="${surface%%|*}"
+    rest="${surface#*|}"
+    cport="${rest%%|*}"
+    rest="${rest#*|}"
+    label="${rest%%|*}"
+    rest="${rest#*|}"
+    scheme="${rest%%|*}"
+    path_suffix="${rest#*|}"
+
+    host_port=$(_published_host_port "$container" "$cport") || continue
+
+    if [ "$header_printed" -eq 0 ]; then
+      echo " "
+      echo "Platform is up. Reachable surfaces:"
+      echo " "
+      header_printed=1
+    fi
+
+    case "$scheme" in
+      http|https)
+        url="${scheme}://localhost:${host_port}${path_suffix}"
+        ;;
+      *)
+        url="${scheme}://localhost:${host_port}"
+        ;;
+    esac
+
+    printf "  %-30s %s\n" "${label}:" "$url"
+  done
+
+  if [ "$header_printed" -eq 1 ]; then
+    echo " "
+  fi
+}


### PR DESCRIPTION
## What

After a successful platform-mode `run.sh` bring-up, print a labeled list of reachable service URLs. The list is driven by **live runtime state**: a URL appears only when a running container is actually publishing that port (queried via `docker port`), and the published host port is read from the real binding rather than hardcoded.

## Why

Operators had no single place to see where each surface is reachable after startup. A static list would lie when a service failed to start or a port was remapped; this reflects what is actually up.

## Behavior

- Prints in platform mode only (gridappsd container started); services-only (`-s`) and no-autostart paths unchanged, no false URLs.
- Prints only after `docker compose up` succeeds.
- Binding-agnostic: `0.0.0.0`, `127.0.0.1`, and IPv6 bindings all resolve to the port and display as `localhost`. A future loopback rebind (planned security hardening) does not blank the banner.
- A surface that is not running or not publishing its port gets no line.

## Test plan

- `bats tests/test_url_banner.bats` (24 cases) via a `docker port` PATH stub: running-and-publishing prints; not-running / not-publishing omitted; 0.0.0.0 / 127.0.0.1 / IPv6 all yield the port; port remap prints the remapped port; empty-state suppresses the header; non-numeric port yields no URL. Assertions check printed URL strings, not just exit code.
- `shellcheck -x run.sh utils.sh`: zero new findings vs baseline.
- Not run against a live platform (run.sh calls `down` first); banner logic verified in isolation.

## Reviews

Dutch (code quality) and Leon (security): both APPROVE-WITH-NITS; all nits applied in the test commit + numeric-port guard.