### PR TITLE
docs: observability stack operator guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Once running, GridAPPS-D is available at:
 | WebSocket | ws://localhost:61614 |
 | OpenWire | tcp://localhost:61616 |
 
-When the observability overlay is active, Grafana and supporting services are also reachable. See [Observability Stack](#observability-stack) in the docker-compose.d section below.
+When the observability overlay is active, Grafana and supporting services are also reachable. See [Observability Stack](docs/observability.md) for endpoints, dashboards, and credentials.
 
 ## Connecting to the Container
 
@@ -143,84 +143,7 @@ nano docker-compose.d/docker-compose_pyvvo.yml
 
 ### Observability Stack
 
-The `docker-compose-grafana.yml.dist` template adds a full observability stack to the platform.
-
-**What it collects:** metrics via Prometheus, logs via Loki, and distributed traces via Tempo. An OpenTelemetry collector receives data from all three pipelines. The gridappsd JVM is instrumented with the OTel Java agent (v2.25.0), injected at startup via a shared volume, so metrics, logs, and traces flow from the JVM process automatically.
-
-#### Activate and deactivate
-
-The overlay is **off by default**. To enable it, copy the template to a live `.yml` file.
-
-```bash
-cp docker-compose.d/docker-compose-grafana.yml.dist docker-compose.d/docker-compose-grafana.yml
-```
-
-**Path A: full platform restart via run.sh**
-Run `./run.sh` after copying the template. The observability services start alongside the base platform. Use `./stop.sh` to stop everything.
-
-```bash
-./run.sh
-```
-
-**Path B: additive activation without a restart (observability-up.sh)**
-If the base platform is already running, bring observability up alongside it without restarting gridappsd:
-
-```bash
-./observability-up.sh
-```
-
-To stop observability services only, leaving the base platform running:
-
-```bash
-./observability-up.sh --down
-```
-
-**Tradeoff:** `run.sh` restarts the entire platform (including gridappsd). `observability-up.sh` does not touch the running base services, making it the right choice when you want to add observability to an already-running session.
-
-#### Endpoints
-
-All observability services bind to `127.0.0.1` (loopback) by default, accessible only from the local machine.
-
-| Service | Default URL | Purpose |
-|---------|-------------|---------|
-| Grafana | http://localhost:4000/ | Dashboards and log/trace/metric exploration |
-| Prometheus | http://localhost:9090/ | Metrics query and scrape status |
-| Loki | http://localhost:3100/ | Log query API |
-| Tempo | http://localhost:3200/ | Trace query API |
-| OTLP gRPC | localhost:4317 | OTel collector ingest (gRPC) |
-| OTLP HTTP | http://localhost:4318/ | OTel collector ingest (HTTP) |
-
-**Remote viewing:** use an SSH tunnel to reach these services from a remote workstation. The ports bind to loopback by default and are not directly reachable over the network.
-
-```bash
-ssh -L 4000:127.0.0.1:4000 <your-host>
-```
-
-Then open `http://localhost:4000/` in your local browser. Repeat the `-L` flag for any other port you need.
-
-**Off-host access:** setting `OBSERVABILITY_BIND_HOST=0.0.0.0` widens the bind to all interfaces. See the security caveats in [Credentials and security](#credentials-and-security) below before doing so.
-
-#### Pre-provisioned dashboards
-
-Three dashboards are provisioned automatically in Grafana:
-
-| Dashboard | Content |
-|-----------|---------|
-| `application-logs` | Log stream from the gridappsd application via Loki |
-| `jvm-metrics` | JVM heap, GC, thread, and CPU metrics via Prometheus |
-| `traces-overview` | Distributed trace list and latency histogram via Tempo |
-
-#### Credentials and security
-
-**Grafana admin password:** set `GRAFANA_ADMIN_PASSWORD` in your environment (or in a `.env` file based on `.env.example`) before starting. If the variable is unset or empty, `run.sh` and `observability-up.sh` auto-generate a strong random password and print it in the startup banner so you can log in. The credential gate operates through the launchers (`run.sh` / `observability-up.sh`) only; a direct `docker compose up` without a non-empty `GRAFANA_ADMIN_PASSWORD` bypasses the auto-generate step and can fall back to the Grafana built-in default.
-
-> **Dev-only caveat:** the auto-generated password appears in stdout, scrollback, and any captured logs. This is intentional for local development convenience. For any deployment beyond a local dev machine, set `GRAFANA_ADMIN_PASSWORD` to a value you control and do not share that value in logs.
-
-**Anonymous access:** disabled by default (`GRAFANA_ANONYMOUS_ENABLED=false`). Set `GRAFANA_ANONYMOUS_ENABLED=true` only for dev or demo use on a trusted network.
-
-**Bind host:** the default `127.0.0.1` binding is the safe posture. Setting `OBSERVABILITY_BIND_HOST=0.0.0.0` exposes Prometheus, Loki, Tempo, Grafana, and the OTLP receiver ports off-host; Prometheus, Loki, Tempo, and OTLP have no authentication. Use this setting only on an isolated, trusted network.
-
-See `.env.example` for a full list of observability environment variable names and their defaults.
+The `docker-compose-grafana.yml.dist` template adds a full observability stack: metrics via Prometheus, logs via Loki, and distributed traces via Tempo, all surfaced through Grafana dashboards. For activation steps (Path A / Path B), endpoint URLs, pre-provisioned dashboards, and credentials/security caveats, see [docs/observability.md](docs/observability.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Once running, GridAPPS-D is available at:
 | WebSocket | ws://localhost:61614 |
 | OpenWire | tcp://localhost:61616 |
 
+When the observability overlay is active, Grafana and supporting services are also reachable. See [Observability Stack](#observability-stack) in the docker-compose.d section below.
+
 ## Connecting to the Container
 
 ```bash
@@ -124,6 +126,7 @@ The directory contains `.dist` files as templates for optional services:
 | `docker-compose_wsu-vvo.yml.dist` | WSU VVO application |
 | `docker-compose_wsu-restoration.yml.cplex` | WSU restoration (requires CPLEX) |
 | `docker-compose_timescaledb.yml.dst` | TimescaleDB for time-series data |
+| `docker-compose-grafana.yml.dist` | Observability stack: Grafana, Prometheus, Loki, Tempo, OTel collector |
 
 To enable an optional service:
 ```bash
@@ -137,6 +140,89 @@ nano docker-compose.d/docker-compose_pyvvo.yml
 ./stop.sh
 ./run.sh
 ```
+
+### Observability Stack
+
+The `docker-compose-grafana.yml.dist` template adds a full observability stack to the platform.
+
+**What it collects:** metrics via Prometheus, logs via Loki, and distributed traces via Tempo. An OpenTelemetry collector receives data from all three pipelines. The gridappsd JVM is instrumented with the OTel Java agent (v2.25.0), injected at startup via a shared volume, so metrics, logs, and traces flow from the JVM process automatically.
+
+#### Activate and deactivate
+
+The overlay is **off by default**. To enable it, copy the template to a live `.yml` file.
+
+```bash
+cp docker-compose.d/docker-compose-grafana.yml.dist docker-compose.d/docker-compose-grafana.yml
+```
+
+**Path A: full platform restart via run.sh**
+Run `./run.sh` after copying the template. The observability services start alongside the base platform. Use `./stop.sh` to stop everything.
+
+```bash
+./run.sh
+```
+
+**Path B: additive activation without a restart (observability-up.sh)**
+If the base platform is already running, bring observability up alongside it without restarting gridappsd:
+
+```bash
+./observability-up.sh
+```
+
+To stop observability services only, leaving the base platform running:
+
+```bash
+./observability-up.sh --down
+```
+
+**Tradeoff:** `run.sh` restarts the entire platform (including gridappsd). `observability-up.sh` does not touch the running base services, making it the right choice when you want to add observability to an already-running session.
+
+#### Endpoints
+
+All observability services bind to `127.0.0.1` (loopback) by default, accessible only from the local machine.
+
+| Service | Default URL | Purpose |
+|---------|-------------|---------|
+| Grafana | http://localhost:4000/ | Dashboards and log/trace/metric exploration |
+| Prometheus | http://localhost:9090/ | Metrics query and scrape status |
+| Loki | http://localhost:3100/ | Log query API |
+| Tempo | http://localhost:3200/ | Trace query API |
+| OTLP gRPC | localhost:4317 | OTel collector ingest (gRPC) |
+| OTLP HTTP | http://localhost:4318/ | OTel collector ingest (HTTP) |
+
+**Remote viewing:** use an SSH tunnel to reach these services from a remote workstation. The ports bind to loopback by default and are not directly reachable over the network.
+
+```bash
+ssh -L 4000:127.0.0.1:4000 <your-host>
+```
+
+Then open `http://localhost:4000/` in your local browser. Repeat the `-L` flag for any other port you need.
+
+**Off-host access:** setting `OBSERVABILITY_BIND_HOST=0.0.0.0` widens the bind to all interfaces. See the security caveats in [Credentials and security](#credentials-and-security) below before doing so.
+
+#### Pre-provisioned dashboards
+
+Three dashboards are provisioned automatically in Grafana:
+
+| Dashboard | Content |
+|-----------|---------|
+| `application-logs` | Log stream from the gridappsd application via Loki |
+| `jvm-metrics` | JVM heap, GC, thread, and CPU metrics via Prometheus |
+| `traces-overview` | Distributed trace list and latency histogram via Tempo |
+
+#### Credentials and security
+
+**Grafana admin password:** set `GRAFANA_ADMIN_PASSWORD` in your environment (or in a `.env` file based on `.env.example`) before starting. If the variable is unset or empty, `run.sh` and `observability-up.sh` auto-generate a strong random password and print it in the startup banner so you can log in. The credential gate operates through the launchers (`run.sh` / `observability-up.sh`) only; a direct `docker compose up` without a non-empty `GRAFANA_ADMIN_PASSWORD` bypasses the auto-generate step and can fall back to the Grafana built-in default.
+
+> **Dev-only caveat:** the auto-generated password appears in stdout, scrollback, and any captured logs. This is intentional for local development convenience. For any deployment beyond a local dev machine, set `GRAFANA_ADMIN_PASSWORD` to a value you control and do not share that value in logs.
+
+**Anonymous access:** disabled by default (`GRAFANA_ANONYMOUS_ENABLED=false`). Set `GRAFANA_ANONYMOUS_ENABLED=true` only for dev or demo use on a trusted network.
+
+**Bind host:** the default `127.0.0.1` binding is the safe posture. Setting `OBSERVABILITY_BIND_HOST=0.0.0.0` exposes Prometheus, Loki, Tempo, Grafana, and the OTLP receiver ports off-host; Prometheus, Loki, Tempo, and OTLP have no authentication. Use this setting only on an isolated, trusted network.
+
+See `.env.example` for a full list of observability environment variable names and their defaults.
+
+---
 
 ### Auto-Generated Files
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,80 @@
+# Observability Stack
+
+The `docker-compose-grafana.yml.dist` template adds a full observability stack to the platform.
+
+**What it collects:** metrics via Prometheus, logs via Loki, and distributed traces via Tempo. An OpenTelemetry collector receives data from all three pipelines. The gridappsd JVM is instrumented with the OTel Java agent (v2.25.0), injected at startup via a shared volume, so metrics, logs, and traces flow from the JVM process automatically.
+
+## Activate and deactivate
+
+The overlay is **off by default**. To enable it, copy the template to a live `.yml` file.
+
+```bash
+cp docker-compose.d/docker-compose-grafana.yml.dist docker-compose.d/docker-compose-grafana.yml
+```
+
+**Path A: full platform restart via run.sh**
+Run `./run.sh` after copying the template. The observability services start alongside the base platform. Use `./stop.sh` to stop everything.
+
+```bash
+./run.sh
+```
+
+**Path B: additive activation without a restart (observability-up.sh)**
+If the base platform is already running, bring observability up alongside it without restarting gridappsd:
+
+```bash
+./observability-up.sh
+```
+
+To stop observability services only, leaving the base platform running:
+
+```bash
+./observability-up.sh --down
+```
+
+**Tradeoff:** `run.sh` restarts the entire platform (including gridappsd). `observability-up.sh` does not touch the running base services, making it the right choice when you want to add observability to an already-running session.
+
+## Endpoints
+
+All observability services bind to `127.0.0.1` (loopback) by default, accessible only from the local machine.
+
+| Service | Default URL | Purpose |
+|---------|-------------|---------|
+| Grafana | http://localhost:4000/ | Dashboards and log/trace/metric exploration |
+| Prometheus | http://localhost:9090/ | Metrics query and scrape status |
+| Loki | http://localhost:3100/ | Log query API |
+| Tempo | http://localhost:3200/ | Trace query API |
+| OTLP gRPC | localhost:4317 | OTel collector ingest (gRPC) |
+| OTLP HTTP | http://localhost:4318/ | OTel collector ingest (HTTP) |
+
+**Remote viewing:** use an SSH tunnel to reach these services from a remote workstation. The ports bind to loopback by default and are not directly reachable over the network.
+
+```bash
+ssh -L 4000:127.0.0.1:4000 <your-host>
+```
+
+Then open `http://localhost:4000/` in your local browser. Repeat the `-L` flag for any other port you need.
+
+**Off-host access:** setting `OBSERVABILITY_BIND_HOST=0.0.0.0` widens the bind to all interfaces. See [Credentials and security](#credentials-and-security) below before doing so.
+
+## Pre-provisioned dashboards
+
+Three dashboards are provisioned automatically in Grafana:
+
+| Dashboard | Content |
+|-----------|---------|
+| `application-logs` | Log stream from the gridappsd application via Loki |
+| `jvm-metrics` | JVM heap, GC, thread, and CPU metrics via Prometheus |
+| `traces-overview` | Distributed trace list and latency histogram via Tempo |
+
+## Credentials and security
+
+**Grafana admin password:** set `GRAFANA_ADMIN_PASSWORD` in your environment (or in a `.env` file based on `.env.example`) before starting. If the variable is unset or empty, `run.sh` and `observability-up.sh` auto-generate a strong random password and print it in the startup banner so you can log in. The credential gate operates through the launchers (`run.sh` / `observability-up.sh`) only; a direct `docker compose up` without a non-empty `GRAFANA_ADMIN_PASSWORD` bypasses the auto-generate step and can fall back to the Grafana built-in default.
+
+> **Dev-only caveat:** the auto-generated password appears in stdout, scrollback, and any captured logs. This is intentional for local development convenience. For any deployment beyond a local dev machine, set `GRAFANA_ADMIN_PASSWORD` to a value you control and do not share that value in logs.
+
+**Anonymous access:** disabled by default (`GRAFANA_ANONYMOUS_ENABLED=false`). Set `GRAFANA_ANONYMOUS_ENABLED=true` only for dev or demo use on a trusted network.
+
+**Bind host:** the default `127.0.0.1` binding is the safe posture. Setting `OBSERVABILITY_BIND_HOST=0.0.0.0` exposes Prometheus, Loki, Tempo, Grafana, and the OTLP receiver ports off-host; Prometheus, Loki, Tempo, and OTLP have no authentication. Use this setting only on an isolated, trusted network.
+
+See `.env.example` for a full list of observability environment variable names and their defaults.


### PR DESCRIPTION
## What

Documents the observability stack (shipped in #69) for operators, extending the existing `docker-compose.d` README section.

Adds an **Observability Stack** subsection covering:
- **What it collects:** metrics (Prometheus), logs (Loki), traces (Tempo), via the OpenTelemetry collector and the OTel Java agent injected into the gridappsd JVM.
- **Activate / deactivate:** the opt-in contract (off by default; copy the `.dist` template to a live `.yml`), with two paths: `run.sh` (full platform restart) and `observability-up.sh` (additive, brings observability up alongside an already-running platform; `--down` removes just observability).
- **Endpoints:** Grafana 4000, Prometheus 9090, Loki 3100, Tempo 3200, OTLP 4317/4318, loopback-bound by default, with the SSH-tunnel note for remote viewing.
- **Dashboards:** the three auto-provisioned (application-logs, jvm-metrics, traces-overview).
- **Credentials + security caveats:** `GRAFANA_ADMIN_PASSWORD` auto-generate behavior and the launcher-only credential gate, anonymous-viewer off by default, and the `OBSERVABILITY_BIND_HOST=0.0.0.0` exposure warning (Prometheus/Loki/Tempo/OTLP are unauthenticated).

## Why

The stack shipped in #69 had no operator-facing documentation. This closes that gap and records the security posture so an operator does not misconfigure the exposure or the credential.

## Reviews

Doc-only change: reviewed by Leon (security/exposure framing) and Dutch (prose/structure), both APPROVE-WITH-NITS; all nits applied (launcher-gate warning, bind-host de-duplication, Grafana added to the exposure list, prose polish).

## Notes

No secret values inline. Consistent with `.env.example`.