### PR TITLE
feat(run.sh): bring blazegraph up and probe before full-stack pull

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -240,19 +240,21 @@ if [ ! -f "$data_dir/$mysql_file" ]; then
 fi
 
 echo " "
-echo "Getting blazegraph status"
-status=$(curl -s --head -w %{http_code} "$url_blazegraph" -o /dev/null)
-debug_msg "blazegraph curl status: $status"
-
-pull_containers
-
-echo " "
 echo "Removing stale containers from previous runs"
 $DOCKER_COMPOSE_CMD $compose_files down --remove-orphans 2>/dev/null
 # Force remove containers by name in case they were orphaned from a different project
 $DOCKER_COMPOSE_CMD $compose_files config 2>/dev/null | grep 'container_name:' | awk '{print $2}' | while read -r name; do
   docker rm -f "$name" 2>/dev/null
 done
+
+echo " "
+echo "Bringing up blazegraph first, so its status is not gated on the rest of the stack pulling images"
+$DOCKER_COMPOSE_CMD $compose_files pull --ignore-pull-failures blazegraph
+$DOCKER_COMPOSE_CMD $compose_files up -d blazegraph
+
+http_status_container 'blazegraph'
+
+pull_containers
 
 echo " "
 echo "Starting the docker containers"
@@ -268,8 +270,6 @@ if [ $container_status -ne 0 ]; then
   echo " "
   exit 1
 fi
-
-http_status_container 'blazegraph'
 
 # sleep just a little longer to make sure blazegraph is ready to receive data.
 sleep 3


### PR DESCRIPTION
## Summary

Reorders `run.sh` startup so `down --remove-orphans` (stale-container cleanup) runs first, then blazegraph is pulled, started, and probed via the existing `http_status_container` helper before the full-stack `pull_containers` and `up -d` run. Previously the blazegraph probe was gated on the entire stack downloading first, since blazegraph carries no `depends_on` relationship to anything else in the compose topology.

Also removes a dead single-shot blazegraph `curl` whose result was only echoed under `debug_msg` and never used, and removes the now-redundant second `http_status_container` call for blazegraph after the full-stack `up`, since blazegraph is already running and probed by that point.

The teardown moved to run before the early `up -d blazegraph` so the later full-stack `down` (already run) does not tear down the blazegraph container just started.

This change was tested live by the operator against a running stack before this PR was opened.

## Test plan

- [x] `bash -n run.sh` passes
- [x] `shellcheck run.sh`: no new findings versus the `develop` baseline (both carry the same pre-existing quoting/style findings unrelated to this change)
- [x] `git diff origin/develop -- run.sh`: 9 insertions / 9 deletions, `run.sh` only
- [x] Live-tested by the operator against a running GridAPPS-D stack